### PR TITLE
Add WarehouseService unit tests

### DIFF
--- a/BarcopoloProject.sln
+++ b/BarcopoloProject.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcopoloWebApi", "BarcopoloWebApi\BarcopoloWebApi.csproj", "{DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BarcopoloWebApi.Tests", "BarcopoloWebApi.Tests\BarcopoloWebApi.Tests.csproj", "{2CF33F9F-CC91-4787-92FE-4DADA0BEDF85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DBD5BAF4-EEB6-4CC4-A737-2DD89A49E4E5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2CF33F9F-CC91-4787-92FE-4DADA0BEDF85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2CF33F9F-CC91-4787-92FE-4DADA0BEDF85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2CF33F9F-CC91-4787-92FE-4DADA0BEDF85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2CF33F9F-CC91-4787-92FE-4DADA0BEDF85}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/BarcopoloWebApi.Tests/BarcopoloWebApi.Tests.csproj
+++ b/BarcopoloWebApi.Tests/BarcopoloWebApi.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BarcopoloWebApi\BarcopoloWebApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/BarcopoloWebApi.Tests/WarehouseServiceTests.cs
+++ b/BarcopoloWebApi.Tests/WarehouseServiceTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using BarcopoloWebApi.Data;
+using BarcopoloWebApi.Entities;
+using BarcopoloWebApi.Enums;
+using BarcopoloWebApi.Services;
+using BarcopoloWebApi.DTOs.Warehouse;
+
+namespace BarcopoloWebApi.Tests
+{
+    public class WarehouseServiceTests
+    {
+        private static DataBaseContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<DataBaseContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            var context = new DataBaseContext(options);
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        private static Person CreateAdmin()
+        {
+            return new Person
+            {
+                Id = 1,
+                FirstName = "Admin",
+                LastName = "User",
+                PhoneNumber = "123",
+                PasswordHash = "hash",
+                Role = SystemRole.admin
+            };
+        }
+
+        private static Address CreateAddress(long id = 1)
+        {
+            return new Address
+            {
+                Id = id,
+                City = "City",
+                Province = "Province",
+                FullAddress = "Address"
+            };
+        }
+
+        private static WarehouseService CreateService(DataBaseContext context)
+            => new WarehouseService(context, NullLogger<WarehouseService>.Instance);
+
+        [Fact]
+        public async Task CreateWarehouse_AddsWarehouse()
+        {
+            using var context = CreateContext();
+            context.Persons.Add(CreateAdmin());
+            context.Addresses.Add(CreateAddress());
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var dto = new CreateWarehouseDto
+            {
+                WarehouseName = "Main",
+                AddressId = 1,
+                InternalTelephone = "111",
+                ManagerPercentage = 10,
+                Rent = 100,
+                TerminalPercentage = 5,
+                VatPercentage = 9,
+                InsuranceAmount = 100,
+                IsActive = true,
+                IsCargoValueMandatory = false,
+                IsDriverNetMandatory = false
+            };
+
+            var result = await service.CreateAsync(dto, 1);
+
+            Assert.NotEqual(0, result.Id);
+            Assert.Equal("Main", result.WarehouseName);
+            Assert.Single(context.Warehouses);
+        }
+
+        [Fact]
+        public async Task GetById_ReturnsWarehouse()
+        {
+            using var context = CreateContext();
+            context.Persons.Add(CreateAdmin());
+            context.Addresses.Add(CreateAddress());
+            var warehouse = new Warehouse { AddressId = 1, WarehouseName = "Main" };
+            context.Warehouses.Add(warehouse);
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+
+            var result = await service.GetByIdAsync(warehouse.Id, 1);
+
+            Assert.Equal(warehouse.WarehouseName, result.WarehouseName);
+            Assert.Equal(warehouse.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task UpdateWarehouse_ChangesValues()
+        {
+            using var context = CreateContext();
+            context.Persons.Add(CreateAdmin());
+            context.Addresses.Add(CreateAddress());
+            var warehouse = new Warehouse { AddressId = 1, WarehouseName = "Main" };
+            context.Warehouses.Add(warehouse);
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+            var dto = new UpdateWarehouseDto { WarehouseName = "Updated" };
+
+            var result = await service.UpdateAsync(warehouse.Id, dto, 1);
+
+            Assert.Equal("Updated", result.WarehouseName);
+            Assert.Equal("Updated", (await context.Warehouses.FindAsync(warehouse.Id))?.WarehouseName);
+        }
+
+        [Fact]
+        public async Task DeleteWarehouse_RemovesWarehouse()
+        {
+            using var context = CreateContext();
+            context.Persons.Add(CreateAdmin());
+            context.Addresses.Add(CreateAddress());
+            var warehouse = new Warehouse { AddressId = 1, WarehouseName = "Main" };
+            context.Warehouses.Add(warehouse);
+            await context.SaveChangesAsync();
+
+            var service = CreateService(context);
+
+            var deleted = await service.DeleteAsync(warehouse.Id, 1);
+
+            Assert.True(deleted);
+            Assert.Empty(context.Warehouses);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project targeting `net9.0`
- implement `WarehouseServiceTests` using an in-memory EF Core context
- include new test project in solution

## Testing
- `dotnet test BarcopoloProject.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865909c86ec8329952638f7f67bdee4